### PR TITLE
Add pip_install to install any desired extra (e.g. datalad-osf)

### DIFF
--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -180,9 +180,7 @@ jobs:
       - name: Install Datalad and some extensions
         uses: ./install
         with:
-          pip_install:
-          - datalad-osf
-          - datalad-next
+          pip_install: datalad-osf datalad-next
       - name: Check Installed
         run: |
           which datalad

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -170,3 +170,21 @@ jobs:
         run: |
           which datalad
           datalad --version | grep 0.18.0
+  
+  install-datalad-osf:
+    runs-on: ubuntu-latest
+    name: Install Datalad with some extensions
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Datalad and some extensions
+        uses: ./install
+        with:
+          pip_install:
+          - datalad-osf
+          - datalad-next
+      - name: Check Installed
+        run: |
+          which datalad
+          which git-remote-osf
+          datalad wtf -S extensions | grep datalad_next

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ for more details.
 | repository  | Repository to install datalad | datalad/datalad | no |
 | branch      | The branch of datalad to use | master | no |
 | install_root| If installed from a branch and full_clone, install to this root | /opt/datalad | no |
+| pip_install | Extra pip installs to do |  | no |
 | release     | A datalad release to use (if defined, over-rides branch) | unset | no |
 | full_clone  | Instead of cloning with `--depth 1`, clone the entire git history (branch only) | false | no |
 | user        | User to provide to GitHub | github-actions | no |
@@ -122,6 +123,7 @@ for more details.
 | repository   | Repository to install datalad | datalad/datalad | no |
 | branch       | The branch of datalad to use | master | no |
 | install_root | If installed from a branch and full_clone, install to this root | /opt/datalad | no |
+| pip_install | Extra pip installs to do |  | no |
 | release      | A datalad release to use (if defined, over-rides branch) | unset | no |
 | full_clone   | Instead of cloning with `--depth 1`, clone the entire git history (branch only) | false | no |
 | user         | User to provide to GitHub | github-actions | no |

--- a/get/action.yaml
+++ b/get/action.yaml
@@ -35,6 +35,9 @@ inputs:
   install_root:
     description: If installed from a branch and full_clone, install to this root (defaults to /opt/datalad)
     default: /opt/datalad
+  pip_install:
+    description: Extra pip installs to do
+    default: ""
   release:
     description: A datalad release to use (if defined, over-rides branch)
     default: ""
@@ -74,6 +77,7 @@ runs:
         full_clone: ${{ inputs.full_clone }}
         repository: ${{ inputs.repository }}
         install_root: ${{ inputs.install_root }}
+        pip_install: ${{ inputs.pip_install }}
       run: ${{ env.action_root }}/install/scripts/install.sh
       shell: bash
 

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -10,6 +10,9 @@ inputs:
   install_root:
     description: If installed from a branch and full_clone, install to this root (defaults to /opt/datalad)
     default: /opt/datalad
+  pip_install:
+    description: Extra pip installs to do
+    default: ""
   release:
     description: A datalad release to use (if defined, over-rides branch)
     default: ""
@@ -35,5 +38,6 @@ runs:
         full_clone: ${{ inputs.full_clone }}
         repository: ${{ inputs.repository }}
         install_root: ${{ inputs.install_root }}
+        pip_install: ${{ inputs.pip_install }}
       run: ${{ github.action_path }}/scripts/install.sh
       shell: bash

--- a/install/scripts/install.sh
+++ b/install/scripts/install.sh
@@ -12,6 +12,7 @@ echo "release: ${release}"
 echo "branch: ${branch}"
 echo "full_clone: ${full_clone}"
 echo "install_root: ${install_root}"
+echo "pip_install: ${pip_install[*]}"
 
 # This is in the install instructions
 git config --global --add user.name "${user}"
@@ -49,4 +50,8 @@ else
         pip install .
         cd -
     fi
+fi
+
+if [ -n "${pip_install}" ]; then
+    pip install "${pip_install[@]}"
 fi

--- a/install/scripts/install.sh
+++ b/install/scripts/install.sh
@@ -12,7 +12,7 @@ echo "release: ${release}"
 echo "branch: ${branch}"
 echo "full_clone: ${full_clone}"
 echo "install_root: ${install_root}"
-echo "pip_install: ${pip_install[*]}"
+echo "pip_install: ${pip_install}"
 
 # This is in the install instructions
 git config --global --add user.name "${user}"
@@ -53,5 +53,6 @@ else
 fi
 
 if [ -n "${pip_install}" ]; then
-    pip install "${pip_install[@]}"
+    # shellcheck disable=SC2086
+    pip install ${pip_install}
 fi


### PR DESCRIPTION
This is desired since otherwise we would not be easily extend datalad with custom remotes which might be needed for some urls etc.

TODOs:
- [x] if doesn't work -- move away from "lists"/bash array I have tried to use here
- [x] also add to `get` when works

Closes #18 