### PR TITLE
Allow for sudo invocations in install -- after all it is on CI anyways

### DIFF
--- a/install/scripts/install.sh
+++ b/install/scripts/install.sh
@@ -23,7 +23,7 @@ python3 -m pip install --upgrade pip
 # Install git annex
 python3 -m pip install datalad-installer
 
-datalad-installer git-annex
+datalad-installer --sudo ok git-annex
 git config --global filter.annex.process "git-annex filter-process"
 
 # Ensure git annex added to path


### PR DESCRIPTION
Otherwise leads to an unneeded conversation when noone listens on custom debian EC2 runner in https://github.com/neuronets/test-aws/pull/4